### PR TITLE
Remove outline on focused state

### DIFF
--- a/realtime-syntaxhighlight.css
+++ b/realtime-syntaxhighlight.css
@@ -9,7 +9,9 @@ pre {
     padding: 1em;
 }
 
-
+code:focus {
+    outline: none;
+}
 
 
 /* realtime editing */


### PR DESCRIPTION
Chrome automatically outlines focused inputs, which in most cases looks terrible, and can even distract from the editing process.

Here's how the example page looks with one of the code snippets selected:

![image](https://user-images.githubusercontent.com/1733366/43423282-43e3b4f4-944c-11e8-935f-98a59893b790.png)
